### PR TITLE
Make the FileInfo class a Dataclass

### DIFF
--- a/dbutils_typehint/fs.py
+++ b/dbutils_typehint/fs.py
@@ -1,24 +1,20 @@
 from typing import Dict, Iterable, Optional
 
+from dataclasses import dataclass
 
+
+@dataclass
 class FileInfo:
-    @property
-    def name(self) -> str:
-        pass
-
-    @property
-    def length(self) -> int:
-        pass
-
-    @property
-    def path(self) -> str:
-        pass
+    name: str
+    length: int
+    path: str
+    dir: bool
 
     def isDir(self) -> bool:
-        pass
+        return self.dir
 
     def isFile(self) -> bool:
-        pass
+        return not self.dir
 
 
 class FS:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
         name='dbutils_typehint',
-        version='0.1.8',
+        version='0.1.9',
         packages=['dbutils_typehint'],
         url='https://github.com/cdeler/dbutils_typehint',
         license='MIT',


### PR DESCRIPTION
This is very nice if we want to use the class for
mocking the return value:

```python
from mock import MagicMock

dbutils.fs.ls = MagicMock(return_value=[
    FileInfo("fokko.avro", 1925, "/tmp/fokko.avro", False)
])
```